### PR TITLE
Flang elemental internal of pure procedure

### DIFF
--- a/compiler/Fortran/flang/elemental-internal-in-pure/README.md
+++ b/compiler/Fortran/flang/elemental-internal-in-pure/README.md
@@ -1,0 +1,30 @@
+# Erroneous compiler error with elemental internal procedure in pure procedure
+
+```yaml
+compiler: flang-new
+version: 18.1.8
+operating system: Arch Linux
+platform: x86_64-pc-linux-gnu
+bug-type: compile-time
+```
+
+# Additional content
+
+The included file, `example.f90`, is sufficient to illustrate the problem.
+
+# Steps to Reproduce
+
+This is triggered when a pure procedure has an internal procedure that
+is elemental. For example, try compiling the included file as shown below.
+
+```text
+$ flang-new example.f90
+error: Semantic errors in example.f90
+./example.f90:8:9: error: An internal subprogram of a pure subprogram must also be pure
+          elemental function add_one(x)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+```
+
+# Workaround
+
+If feasible, move the procedure to no longer be internal.

--- a/compiler/Fortran/flang/elemental-internal-in-pure/example.f90
+++ b/compiler/Fortran/flang/elemental-internal-in-pure/example.f90
@@ -1,0 +1,18 @@
+module example_mod
+contains
+    pure function add_one_to_each(a)
+        integer, intent(in) :: a(:)
+        integer :: add_one_to_each(size(a))
+        add_one_to_each = add_one(a)
+    contains
+        elemental function add_one(x)
+            integer, intent(in) :: x
+            integer :: add_one
+            add_one = x + 1
+        end function
+    end function
+end module
+
+use example_mod
+print *, add_one_to_each([1, 2, 3])
+end


### PR DESCRIPTION
Flang is currently rejecting code with an elemental internal procedure in a pure procedure.