### PR TITLE
Create reproducer for procedure dummy argument crash

### DIFF
--- a/compiler/Fortran/flang/mapped-object-invalid-permission/README.md
+++ b/compiler/Fortran/flang/mapped-object-invalid-permission/README.md
@@ -1,0 +1,23 @@
+# Invalid Permissions for Mapped Object
+
+```yaml
+compiler: flang-new
+version: 18.1.8
+operating system: Arch Linux
+platform: x86_64-pc-linux-gnu
+bug-type: compile-time
+```
+
+# Additional content
+
+The included file, `example.f90`, is sufficient to illustrate the problem.
+
+# Steps to Reproduce
+
+A segfault occurs when calling a procedure dummy argument if the actual
+argument is an internal procedure that accesses as host associated
+dummy argument. When run with the debugger the fault is reported as
+
+```text
+signal SIGSEGV: invalid permissions for mapped object (fault address: 0x7fffffffe310)
+```

--- a/compiler/Fortran/flang/mapped-object-invalid-permission/example.f90
+++ b/compiler/Fortran/flang/mapped-object-invalid-permission/example.f90
@@ -1,0 +1,24 @@
+module example_mod
+    abstract interface
+        subroutine sub_i
+        end subroutine
+    end interface
+contains
+    subroutine call_internal(string)
+        character(len=*), intent(in) :: string
+        call call_it(print_it)
+    contains
+        subroutine print_it
+            print *, string
+        end subroutine
+    end subroutine
+    subroutine call_it(sub)
+        procedure(sub_i) :: sub
+        call sub
+    end subroutine
+end module
+
+program example_prog
+    use example_mod
+    call call_internal("Hello")
+end program


### PR DESCRIPTION
Flang crashes when trying to call a dummy procedure where the actual procedure is an internal procedure that references a host associated dummy argument (see example).